### PR TITLE
fix: package.json err-code module missing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "ts-jest": "^29.1.4",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "err-code": "^2.0.3"
   },
   "dependencies": {
     "@jup-ag/api": "^6.0.29",


### PR DESCRIPTION
Error: Cannot find module 'err-code'
Require stack:
- D:\code\web3\solscan\node_modules\promise-retry\index.js